### PR TITLE
make kino requirement more permissive

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule SmartCellCommand.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:kino, "~> 0.6.1"}
+      {:kino, "~> 0.6"}
     ]
   end
 end


### PR DESCRIPTION
# What
Hello! Thank you for the very useful smart cell.  I was trying to use it with another smart cell that I wrote and found that the `kino` dependency was too strict.

This loosens  it up enough that any version up until 1.0.0 should work.  Let me know if you have any concerns.